### PR TITLE
Try to fix a bug in making filename for documentation

### DIFF
--- a/restfulpy/testing.py
+++ b/restfulpy/testing.py
@@ -198,7 +198,7 @@ class ApplicableTestCase:
     def _get_story_filename(cls, story):
         cls._ensure_directory(cls.__story_directory__)
         title = story.title.lower().replace(' ', '-')
-        title = title.replace('/', ' or ')
+        title = title.replace('/', '_or_')
         entity = story.base_call.url.split('/')[2]
         filename = path.join(
             cls.__story_directory__,

--- a/restfulpy/testing.py
+++ b/restfulpy/testing.py
@@ -198,6 +198,7 @@ class ApplicableTestCase:
     def _get_story_filename(cls, story):
         cls._ensure_directory(cls.__story_directory__)
         title = story.title.lower().replace(' ', '-')
+        title = title.replace('/', ' or ')
         entity = story.base_call.url.split('/')[2]
         filename = path.join(
             cls.__story_directory__,

--- a/restfulpy/testing.py
+++ b/restfulpy/testing.py
@@ -195,27 +195,38 @@ class ApplicableTestCase:
             os.makedirs(d, exist_ok=True)
 
     @classmethod
-    def _get_story_filename(cls, story):
-        cls._ensure_directory(cls.__story_directory__)
+    def _get_document_filename(cls, directory, story):
+        cls._ensure_directory(directory)
         title = story.title.lower().replace(' ', '-')
         title = title.replace('/', '-or-')
-        entity = story.base_call.url.split('/')[2]
+        url_parts = story.base_call.url.split('/')
+        if len(url_parts) >= 3:
+            entity = url_parts[2]
+        elif len(url_parts) == 2:
+            entity = 'root'
+        else:
+            raise ValueError(
+                'Url should be started with /apiv1/ following entity name'
+            )
+
         filename = path.join(
-            cls.__story_directory__,
-            f'{story.base_call.verb}-{entity}--{title}.yml'
+            directory,
+            f'{story.base_call.verb}-{entity}--{title}'
         )
         return filename
 
     @classmethod
+    def _get_story_filename(cls, story):
+        filename = cls._get_document_filename(cls.__story_directory__, story)
+        return f'{filename}.yml'
+
+    @classmethod
     def _get_markdown_filename(cls, story):
-        cls._ensure_directory(cls.__api_documentation_directory__)
-        title = story.title.lower().replace(' ', '-')
-        entity = story.base_call.url.split('/')[2]
-        filename = path.join(
+        filename = cls._get_document_filename(
             cls.__api_documentation_directory__,
-            f'{story.base_call.verb}-{entity}--{title}.md'
+            story
         )
-        return filename
+        return f'{filename}.md'
 
     def given(self, *a, autodoc=True, **kw):
         if self._authentication_token is not None:

--- a/restfulpy/testing.py
+++ b/restfulpy/testing.py
@@ -198,7 +198,7 @@ class ApplicableTestCase:
     def _get_story_filename(cls, story):
         cls._ensure_directory(cls.__story_directory__)
         title = story.title.lower().replace(' ', '-')
-        title = title.replace('/', '_or_')
+        title = title.replace('/', '-or-')
         entity = story.base_call.url.split('/')[2]
         filename = path.join(
             cls.__story_directory__,

--- a/restfulpy/tests/test_documentaion.py
+++ b/restfulpy/tests/test_documentaion.py
@@ -1,0 +1,50 @@
+from os import path, mkdir
+
+from bddrest.authoring import response, status
+from nanohttp import action, RegexRouteController
+
+from restfulpy.controllers import RootController
+from restfulpy.testing import ApplicableTestCase
+
+
+HERE = path.abspath(path.dirname(__file__))
+DATA_DIRECTORY = path.abspath(path.join(HERE, '../../data'))
+
+
+class Root(RegexRouteController):
+
+    def __init__(self):
+        return super().__init__([
+            ('/apiv1/documents', self.get), ('/', self.index)
+        ])
+
+    @action
+    def get(self):
+        return 'Index'
+
+    @action
+    def index(self):
+        return 'Index'
+
+
+class TestApplication(ApplicableTestCase):
+    __controller_factory__ = Root
+    __story_directory__ = path.join(DATA_DIRECTORY, 'stories')
+
+    def test_index(self):
+        with self.given(
+            'There is a / in the title',
+            '/apiv1/documents',
+            'GET'
+        ):
+            assert status == 200
+            assert response.body == b'Index'
+
+    def test_root_request(self):
+        with self.given(
+            'Requesting on the root controller',
+            '/',
+            'INDEX',
+        ):
+            assert status == 200
+


### PR DESCRIPTION
- The `/` character in the title of a request makes an exception in terms of documenting.
- The exception has been handled replacing `/` with ` or ` 
- When trying to fix the bug, another exception raised when trying to request on the root controller, so a test is written to report the bug