### PR TITLE
The protected in activated_at and deactivated_at is removed

### DIFF
--- a/restfulpy/orm/mixins.py
+++ b/restfulpy/orm/mixins.py
@@ -133,7 +133,6 @@ class AutoActivationMixin(ActivationMixin):
         nullable=True,
         json='activatedAt',
         readonly=True,
-        protected=True,
         default=datetime.utcnow
     )
 
@@ -145,7 +144,6 @@ class DeactivationMixin(ActivationMixin):
         nullable=True,
         json='deactivatedAt',
         readonly=True,
-        protected=True
     )
 
     @ActivationMixin.is_active.setter


### PR DESCRIPTION
Since activate_at and deactivated_at should be displayed in response, the protected property in these fields is removed. 