### PR TITLE
Fixing the pattern description and the not none to camel case

### DIFF
--- a/restfulpy/orm/metadata.py
+++ b/restfulpy/orm/metadata.py
@@ -25,10 +25,10 @@ class FieldInfo:
 
         return {
             'type': type_.__name__ if self.type_ else None,
-            'not_none': self.not_none,
+            'notNone': self.not_none,
             'required': self.required,
             'pattern': self.pattern,
-            'pattern_description': self.pattern_description,
+            'patternDescription': self.pattern_description,
             'maxLength': self.max_length,
             'minLength': self.min_length,
             'readonly': self.readonly,

--- a/restfulpy/tests/test_base_model.py
+++ b/restfulpy/tests/test_base_model.py
@@ -310,14 +310,14 @@ class TestBaseModel(ApplicableTestCase):
             assert fields['firstName']['name'] == 'firstName'
             assert fields['firstName']['label'] == 'First Name'
             assert fields['firstName']['key'] == 'first_name'
-            assert fields['lastName']['not_none'] == True
+            assert fields['lastName']['notNone'] == True
             assert fields['lastName']['label'] == 'Last Name'
             assert fields['weight']['default'] == 50
             assert fields['weight']['type'] == 'float'
             assert fields['weight']['label'] == 'Weight'
-            assert fields['visible']['not_none'] == None
+            assert fields['visible']['notNone'] == None
             assert fields['phone']['label'] == 'Phone'
-            assert fields['phone']['pattern_description'] == \
+            assert fields['phone']['patternDescription'] == \
                 'The phone number cannot contain alphabet'
             assert fields['password']['label'] == 'Password'
 


### PR DESCRIPTION
The metadata fields must be camel case.