### PR TITLE
Metadata bug for some types

### DIFF
--- a/restfulpy/orm/metadata.py
+++ b/restfulpy/orm/metadata.py
@@ -70,8 +70,8 @@ class MetadataField(FieldInfo):
 
         key = c.key
 
-        if hasattr(c, 'default')
-                and c.default
+        if hasattr(c, 'default') \
+                and c.default \
                 and hasattr(c.default, 'is_scalar'):
             default = c.default.arg if c.default.is_scalar else None
         else:

--- a/restfulpy/orm/metadata.py
+++ b/restfulpy/orm/metadata.py
@@ -70,7 +70,9 @@ class MetadataField(FieldInfo):
 
         key = c.key
 
-        if hasattr(c, 'default') and c.default:
+        if hasattr(c, 'default')
+                and c.default
+                and hasattr(c.default, 'is_scalar'):
             default = c.default.arg if c.default.is_scalar else None
         else:
             default = None


### PR DESCRIPTION
Fixed metadata bug for types that don't have `default.is_scalar` like Sequence.